### PR TITLE
fix for when there is a black bar

### DIFF
--- a/hn.js
+++ b/hn.js
@@ -23,7 +23,11 @@ javascript:(function() {
                 var span_html = '<span style=\'cursor:pointer;margin-left:10px;\' class=\'expand-handle\'>[-]</span>';
                 
                 if (window.location.href.indexOf('item?id=') != -1) {
-                    $('center > table > tbody > tr:eq(2) > td > table:eq(1) span.comhead').append(span_html);
+					if ($('center > table > tbody > tr').length > 4) {
+			        	$('center > table > tbody > tr:eq(3) > td > table:eq(1) span.comhead').append(span_html);
+					} else {
+						$('center > table > tbody > tr:eq(2) > td > table:eq(1) span.comhead').append(span_html);
+					}
                 } else if (window.location.href.indexOf('threads?id=') != -1) {
                     $('center > table > tbody > tr > td > table span.comhead').append(span_html);
                 }


### PR DESCRIPTION
Hi,

Sometimes HN will add a table element, ie black bar or "the day we fight back" banner as it was today, which breaks the script.

This pull request is my proposed fix. Please consider updating your Chrome extension with it.

Thanks!

Mark
